### PR TITLE
fix(ci): Images tagged with "latest" or semantic versioning patterns should not be pruned

### DIFF
--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -87,7 +87,7 @@ jobs:
               const images = packages.reduce((pkgs, pkg) => {
                 let tag = 'dangling';
 
-                if (pkg.tags.includes('latest') || pkg.tags.find(tag => /^v\d+\.\d+\.\d$/.test(tag))) {
+                if (pkg.tags.includes('latest') || pkg.tags.find(tag => /^v\d+\.\d+\.\d+$/.test(tag))) {
                   // Skip latest and release images
                   return pkgs;
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated image pruning workflow to validate and exclude packages earlier. Images tagged "latest" or matching semantic version patterns are now skipped sooner, consolidating exclusion logic and removing the prior separate "skip latest" step. This changes which images are retained versus pruned during cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->