### PR TITLE
feat(ci): ensure `prune-images` workflow is compatible with legacy versioning schema

### DIFF
--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -95,7 +95,7 @@ jobs:
                 if (pkg.tags.length > 0) {
                   const image_tag = pkg.tags.find(tag => /^(\d+\.\d+\.\d+-)?[\w-]+\.[a-f0-9]{8}$/.test(tag));
                   tag = image_tag
-                    ? image_tag.replace(/^(\d+\.\d+\.\d+-)?(.*)\.[a-f0-9]{8}$/, '$1')
+                    ? image_tag.replace(/^(\d+\.\d+\.\d+-)?(.*)\.[a-f0-9]{8}$/, '$2')
                     : pkg.tags.at(1);
 
                   if (!tag) {


### PR DESCRIPTION
Previously we're using `{version}-{branch}.{commit-sha}` pattern to tag docker image from branches, but since #25 the versioning format is changed to `{branch}.{commit-sha}` but `prune-images` workflow remain couldn't recognize the new format and will prune the new images instead of the old ones.

<img width="733" height="468" alt="image" src="https://github.com/user-attachments/assets/314577ea-6de1-41d1-90e6-7aeea735a17f" />

That said we need a way to make it recognize the new format and prune the old ones as shown in [this](https://github.com/feryardiant/learn-bun-elysia/actions/runs/21346666022/job/61435559022?pr=27) workflow

<img width="711" height="479" alt="image" src="https://github.com/user-attachments/assets/b39138c4-cd80-4faf-aab0-9c61d3ee9788" />

The old image that still using legacy version format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved image tag extraction to accept tags with or without version prefixes, providing more flexible handling while maintaining consistent fallback behavior for automated image management processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->