### PR TITLE
fix(ci): fix api-schema release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Download API Schema artifact
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
Fix `failed to run git: fatal: not a git repository` on [previous release's](https://github.com/feryardiant/learn-bun-elysia/actions/runs/21612643380/job/62284850542) ci due to missing repo checkout from #42. And apparently @coderabbitai couldn't catch this issue in advance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to include a repository checkout step, ensuring the release pipeline has proper access to the codebase during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->