### PR TITLE
feat(otel): add ability to track `prepareRelationalQuery`

### DIFF
--- a/src/utils/otel.util.ts
+++ b/src/utils/otel.util.ts
@@ -8,7 +8,9 @@ import {
   type Tracer,
 } from '@opentelemetry/api'
 import { ATTR_OTEL_SCOPE_VERSION } from '@opentelemetry/semantic-conventions'
+import type { PgSession } from 'drizzle-orm/pg-core'
 import { ENV } from '~/config'
+import type { AppDatabase } from '~/plugins/database.plugin'
 
 const instrumented: Record<string, boolean> = {}
 
@@ -49,6 +51,27 @@ export function recordableClass(): ClassDecorator {
       // Mark the method as instrumented
       instrumented[spanName] = true
     }
+  }
+}
+
+function traceRelationalQuery(db?: AppDatabase) {
+  // @ts-ignore private property
+  const session = db?.session as PgSession
+
+  if (typeof session?.prepareRelationalQuery !== 'function') return
+
+  const originalMethod = session.prepareRelationalQuery
+  const attributes: Attributes = {
+    'db.adapter': db?.$client.options.adapter,
+  }
+
+  session.prepareRelationalQuery = function (query, ...args) {
+    attributes['db.statement'] = query.sql
+    console.log(args)
+
+    return record('spanName', attributes, () =>
+      originalMethod.apply(this, [query, ...args]),
+    )
   }
 }
 

--- a/src/utils/otel.util.ts
+++ b/src/utils/otel.util.ts
@@ -55,7 +55,7 @@ export function recordableClass(): ClassDecorator {
 }
 
 function wrapDatabaseSession(db: AppDatabase) {
-  // @ts-ignore private property
+  // @ts-expect-error accessing private `session` property
   const session = db.session as PgSession & {
     __otelPatched_session_prepareRelationalQuery?: boolean
   }
@@ -90,10 +90,9 @@ function wrapPreparedQuery<T extends PatchedPrepareQuery>(prepared: T) {
       'db.statement': query.sql,
     }
 
-    for (const p in query.params) {
+    for (const [p, value] of Object.entries(query.params)) {
       const key = getQueryParamKey(p)
-
-      attributes[`db.params.${key}`] = query.params[p] as string
+      attributes[`db.params.${key}`] = value as string
     }
 
     return record(tracer, `drizzle.${operation}`, attributes, () =>

--- a/src/utils/otel.util.ts
+++ b/src/utils/otel.util.ts
@@ -91,7 +91,9 @@ function wrapPreparedQuery<T extends PatchedPrepareQuery>(prepared: T) {
     }
 
     for (const p in query.params) {
-      attributes[`db.params.$${Number(p) + 1}`] = query.params[p] as string
+      const key = getQueryParamKey(p)
+
+      attributes[`db.params.${key}`] = query.params[p] as string
     }
 
     return record(tracer, `drizzle.${operation}`, attributes, () =>
@@ -100,6 +102,10 @@ function wrapPreparedQuery<T extends PatchedPrepareQuery>(prepared: T) {
   }
 
   return prepared
+}
+
+function getQueryParamKey(p: string) {
+  return `$${Number(p) + 1}`
 }
 
 /**

--- a/src/utils/otel.util.ts
+++ b/src/utils/otel.util.ts
@@ -7,12 +7,9 @@ import {
   type Span,
   type Tracer,
 } from '@opentelemetry/api'
-import { ATTR_OTEL_SCOPE_VERSION } from '@opentelemetry/semantic-conventions'
-import type { PgSession } from 'drizzle-orm/pg-core'
+import type { PgBasePreparedQuery, PgSession } from 'drizzle-orm/pg-core'
 import { ENV } from '~/config'
 import type { AppDatabase } from '~/plugins/database.plugin'
-
-const instrumented: Record<string, boolean> = {}
 
 /**
  * Decorator to mark a class as recordable for OpenTelemetry tracing.
@@ -23,9 +20,10 @@ export function recordableClass(): ClassDecorator {
 
     for (const methodName of Object.getOwnPropertyNames(prototype)) {
       const spanName = `${className}.${methodName}`
+      const instrumentFlag = `__otelPatched_${spanName}`
 
       // Skip the constructor or already instrumented methods
-      if (methodName === 'constructor' || instrumented[spanName]) continue
+      if (methodName === 'constructor' || prototype[instrumentFlag]) continue
 
       const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName)
 
@@ -34,45 +32,74 @@ export function recordableClass(): ClassDecorator {
 
       const originalMethod = descriptor.value as Function
       const attributes: Attributes = {
-        [ATTR_OTEL_SCOPE_VERSION]: ENV.APP_VERSION,
         'repository.name': className,
         'repository.operation': methodName,
       }
+
+      // Mark the method as instrumented
+      prototype[instrumentFlag] = true
 
       // Overwrite the method on the prototype
       prototype[methodName] = function (...args: unknown[]) {
         const tracer = trace.getTracer(ENV.APP_NAME)
 
+        // Patch database instance when this decorator applied in repository class
+        this.db && wrapDatabaseSession(this.db)
+
         return record(tracer, spanName, attributes, () =>
           originalMethod.apply(this, args),
         )
       }
-
-      // Mark the method as instrumented
-      instrumented[spanName] = true
     }
   }
 }
 
-function traceRelationalQuery(db?: AppDatabase) {
+function wrapDatabaseSession(db: AppDatabase) {
   // @ts-ignore private property
-  const session = db?.session as PgSession
-
-  if (typeof session?.prepareRelationalQuery !== 'function') return
-
-  const originalMethod = session.prepareRelationalQuery
-  const attributes: Attributes = {
-    'db.adapter': db?.$client.options.adapter,
+  const session = db.session as PgSession & {
+    __otelPatched_session_prepareRelationalQuery?: boolean
   }
 
-  session.prepareRelationalQuery = function (query, ...args) {
-    attributes['db.statement'] = query.sql
-    console.log(args)
+  if (!session.__otelPatched_session_prepareRelationalQuery) {
+    const originalRelationalQuery = session.prepareRelationalQuery
 
-    return record('spanName', attributes, () =>
-      originalMethod.apply(this, [query, ...args]),
+    session.__otelPatched_session_prepareRelationalQuery = true
+    session.prepareRelationalQuery = function (...args) {
+      return wrapPreparedQuery(originalRelationalQuery.apply(this, args))
+    }
+  }
+}
+
+interface PatchedPrepareQuery extends PgBasePreparedQuery {
+  __otelPatched_preparedQuery_execute?: boolean
+}
+
+function wrapPreparedQuery<T extends PatchedPrepareQuery>(prepared: T) {
+  if (prepared.__otelPatched_preparedQuery_execute) return prepared
+
+  const originalExecute = prepared.execute
+
+  prepared.__otelPatched_preparedQuery_execute = true
+  prepared.execute = function (...args) {
+    const query = prepared.getQuery()
+    const [operation] = query.sql.split(' ')
+
+    const tracer = trace.getTracer(ENV.APP_NAME)
+    const attributes: Attributes = {
+      'db.operation': operation?.toUpperCase(),
+      'db.statement': query.sql,
+    }
+
+    for (const p in query.params) {
+      attributes[`db.params.$${Number(p) + 1}`] = query.params[p] as string
+    }
+
+    return record(tracer, `drizzle.${operation}`, attributes, () =>
+      originalExecute.apply(this, args),
     )
   }
+
+  return prepared
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database query instrumentation for more accurate and consistent tracing.
  * Captures DB operation type, SQL statement, and query parameters for richer telemetry.
* **Bug Fixes**
  * Prevents duplicate instrumentation to reduce noisy or duplicate traces and nested span clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->